### PR TITLE
Fixed a sentence that was not clear

### DIFF
--- a/website-docs/motivations.md
+++ b/website-docs/motivations.md
@@ -133,7 +133,7 @@ RSocket supports session resumption, allowing a simple handshake to resume a cli
 
 RSocket supports two forms of application-level flow control to help protect both client and server resources from being overwhelmed: “Reactive Streams” `request(n)` async pull, and leasing.
 
-This protocol is designed for use both in datacenter, server-to-server use cases, as well as server-to-device use cases over the internet, such as to mobile devices or browsers.
+This protocol is designed to be used in both datacenter and server-to-server use cases. As well as server-to-device use cases over the internet, such as to mobile devices or browsers
 
 ### “Reactive Streams” `request(n)` Async Pull
 


### PR DESCRIPTION
> This protocol is designed for use both in datacenter, server-to-server use cases, as well as server-to-device use cases over the internet, such as to mobile devices or browsers.


was not very clear on the `for use both in`