### PR TITLE
Fix "Edit this page" link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,7 +63,7 @@ module.exports = {
           "path": path.resolve("content-docs"),
           "showLastUpdateAuthor": true,
           "showLastUpdateTime": true,
-          "editUrl": "https://github.com/rsocket/rsocket-website/edit/master/content-docs/",
+          "editUrl": "https://github.com/rsocket/rsocket-website/edit/master/",
           "sidebarPath": path.resolve("./sidebars.js"),
         },
         "theme": {


### PR DESCRIPTION
Fixes duplicate `/content-docs/content-docs/` in "Edit this page" link. Inspired from https://github.com/facebook/docusaurus/issues/3152#issuecomment-666382023.

Duplicates #45 .

Before:

![image](https://user-images.githubusercontent.com/6305490/110574333-8da1e280-8122-11eb-8167-8a150c46f074.png)

After:

![image](https://user-images.githubusercontent.com/6305490/110574427-b3c78280-8122-11eb-8571-86cc83e99218.png)
