### PR TITLE
docs: add swift references to homepage and implementations page

### DIFF
--- a/content-docs/implementations.md
+++ b/content-docs/implementations.md
@@ -28,4 +28,4 @@ The core scope includes the following (and is not limited to) :
 | rsocket-go     | <ul><li>Go NET (TCP)</li></ul>                                                          | 1.0     |              |            |         |     |
 | rsocket-kotlin | <ul><li>ktor multiplatform<br />(TCP, websocket)</li></ul>                              | 1.0     | x            |            |         |     |
 | rsocket-py     | <ul><li>asyncio (TCP)</li></ul>                                                         | 1.0     |              |            |         |     |
-| rsocket-swift  | <ul><li>websocket</li></ul>                                                             | 0.0.1   |              |            |         |     |
+| rsocket-swift  | <ul><li>SwiftNIO (TCP, WebSocket)</li><li>Network.framework through NIO Transport Services</li></ul>                                                             | 0.0.1   |              |            |         |     |

--- a/content-docs/implementations.md
+++ b/content-docs/implementations.md
@@ -28,3 +28,4 @@ The core scope includes the following (and is not limited to) :
 | rsocket-go     | <ul><li>Go NET (TCP)</li></ul>                                                          | 1.0     |              |            |         |     |
 | rsocket-kotlin | <ul><li>ktor multiplatform<br />(TCP, websocket)</li></ul>                              | 1.0     | x            |            |         |     |
 | rsocket-py     | <ul><li>asyncio (TCP)</li></ul>                                                         | 1.0     |              |            |         |     |
+| rsocket-swift  | <ul><li>websocket</li></ul>                                                             | 0.0.1   |              |            |         |     |

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -170,6 +170,10 @@ function Home() {
     {
       title: "C++",
       url: "https://github.com/rsocket/rsocket-cpp"
+    },
+    {
+      title: "Swift",
+      url: "https://github.com/rsocket/rsocket-swift"
     }
   ];
 


### PR DESCRIPTION
add swift references to homepage and implementations page

### Motivation:

Bring visibility to ongoing work for RSocket in the Swift community.

### Modifications:

Added link to `rsocket-swift` on homepage and added `rsocket-swift` entries to table on implementations page.

### Result:

See preview.
