### PR TITLE
fix: use proper property + name meta tag attributes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,8 +93,9 @@ module.exports = {
       "additionalLanguages": ["kotlin"],
     },
     "metadatas": [
-      { name: "og:image", content: `${baseUrl}img/social/rsocket-io-facebook-og.jpg` },
-      { name: "twitter:card", content: `${baseUrl}img/social/rsocket-io-twitter-card.jpg` },
+      { property: "og:image", content: `${baseUrl}img/social/rsocket-io-facebook-og.jpg` },
+      { name: "twitter:image", content: `${baseUrl}img/social/rsocket-io-twitter-card.jpg` },
+      { name: "twitter:site", content: "@rsocket" },
     ],
     "navbar": {
       "title": "RSocket",


### PR DESCRIPTION
Fix attributes on meta tags for social meta data based on docs for respective social media sites.

### Motivation:

Twitter docs say to use `name`, Facebook docs say to use `property`.

https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image
https://developers.facebook.com/docs/sharing/webmasters/

### Modifications:

Update config.

### Result:

N/A
