### PR TITLE
fix link to FAQ

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -260,7 +260,7 @@ function Home() {
                 'button button--secondary button--lg',
                 styles.getStarted,
               )}
-              to={withBaseUrl('about/')}
+              to={withBaseUrl('about/faq')}
             >
               Read the FAQ
             </Link>


### PR DESCRIPTION
"Read the FAQ" Button on the main Page links to `/about` (which result in a "Page Not Found" error) but should link to `/about/faq`.

BTW: I have tested it locally and it looks like our dependencies have many security vulnerabilities:
<img width="495" alt="Screen Shot 2021-05-15 at 11 36 34 AM" src="https://user-images.githubusercontent.com/5688874/118355811-77753000-b572-11eb-9522-9f5183d9c5ea.png">
