### PR TITLE
Fix a broken list

### DIFF
--- a/content-docs/about/protocol.md
+++ b/content-docs/about/protocol.md
@@ -1274,7 +1274,6 @@ conditions that do not make sense given the current context. Clarifications are 
 1. Lack of LEASE frames that stops new Requests is an application concern and SHALL NOT be handled by the protocol.
 
 1. If a PAYLOAD for a REQUEST_RESPONSE is received that does not have a COMPLETE flag set, the implementation MUST
-
 assume it is set and act accordingly.
 
 1. Reassembly of PAYLOADs and REQUEST_CHANNELs MUST assume the possibility of an infinite stream.


### PR DESCRIPTION
Fix a broken list in the `Handling the Unexpected` section in protocol spec.

### Motivation:

I found this display issue when reading the RSocket protocol spec in rsocket.io. The broken list is appeared in the [Handling the Unexpected](https://rsocket.io/about/protocol/#handling-the-unexpected).

### Modifications:

Just delete one blank line.

### Result:

Should fix this display issue.
