### PR TITLE
Update index.mdx

### DIFF
--- a/content-docs/guides/rsocket-js/index.mdx
+++ b/content-docs/guides/rsocket-js/index.mdx
@@ -4,7 +4,7 @@ title: rsocket-js
 sidebar_label: Introduction
 ---
 
-`rsocket-js` implements the 1.0 version of the [RSocket protocol](about/protocol)
+`rsocket-js` implements the 1.0 version of the [RSocket protocol](https://rsocket.io/about/protocol)
 and is designed for use in Node.js and browsers.
 
 ## Packages


### PR DESCRIPTION
Corrected the link ' RSocket protocol ' to https://rsocket.io/about/protocol/ as it led to NOT FOUND (in Guides section).

### Motivation:

To correct the guide.

### Modifications:

Corrected the link ' RSocket protocol ' to https://rsocket.io/about/protocol/ as it led to NOT FOUND (in Guides section).

### Result:

Link works :)
