### PR TITLE
Docs/syntax theme and index python link

### DIFF
--- a/content-docs/about/implementations.md
+++ b/content-docs/about/implementations.md
@@ -19,13 +19,13 @@ The core scope includes the following (and is not limited to) :
 
 ## Supported Core Protocol Features Matrix
 
-| Driver         | Transport(s)                                                                            | Version | Core Support | Resumption | Leasing | RPC |
-| -------------- | --------------------------------------------------------------------------------------- | ------- | ------------ | ---------- | ------- | --- |
-| [rsocket-java](https://github.com/rsocket/rsocket-java)   | <ul><li>aeron (UDP)</li><li>akka</li><li>reactor-netty <br />(TCP, websocket)</li></ul> | 1.0     | x            |            | x       | x   |
-| [rsocket-js](https://github.com/rsocket/rsocket-js)     | <ul><li>nodejs net (TCP)</li><li>plain (websocket)</li></ul>                            | 1.0     | x            | x          |         | x   |
-| [rsocket-net](https://github.com/rsocket/rsocket-net)    | <ul><li>System.Net <br />(TCP, websocket)</li></ul>                                     | 1.0     | x            |            |         | x   |
-| [rsocket-cpp](https://github.com/rsocket/rsocket-cpp)    | <ul><li>Folly (TCP)</li></ul>                                                           | 1.0     | x            | x          |         |     |
-| [rsocket-go](https://github.com/rsocket/rsocket-go)     | <ul><li>Go NET (TCP)</li></ul>                                                          | 1.0     |              |            |         |     |
-| [rsocket-kotlin](https://github.com/rsocket/rsocket-kotlin) | <ul><li>ktor multiplatform<br />(TCP, websocket)</li></ul>                              | 1.0     | x            |            |         |     |
-| [rsocket-py](https://github.com/rsocket/rsocket-py)     | <ul><li>asyncio (TCP)</li></ul>                                                         | 1.0     |              |            |         |     |
-| [rsocket-swift](https://github.com/rsocket/rsocket-swift)  | <ul><li>SwiftNIO (TCP, WebSocket)</li><li>Network.framework through NIO Transport Services</li></ul>                                                             | 0.0.1   |              |            |         |     |
+| Driver                                                      | Transport(s)                                                                                         | Version | Core Support | Resumption | Leasing | RPC |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------ | ---------- | ------- | --- |
+| [rsocket-java](https://github.com/rsocket/rsocket-java)     | <ul><li>aeron (UDP)</li><li>akka</li><li>reactor-netty <br />(TCP, websocket)</li></ul>              | 1.0     | x            |            | x       | x   |
+| [rsocket-js](https://github.com/rsocket/rsocket-js)         | <ul><li>nodejs net (TCP)</li><li>plain (websocket)</li></ul>                                         | 1.0     | x            | x          |         | x   |
+| [rsocket-net](https://github.com/rsocket/rsocket-net)       | <ul><li>System.Net <br />(TCP, websocket)</li></ul>                                                  | 1.0     | x            |            |         | x   |
+| [rsocket-cpp](https://github.com/rsocket/rsocket-cpp)       | <ul><li>Folly (TCP)</li></ul>                                                                        | 1.0     | x            | x          |         |     |
+| [rsocket-go](https://github.com/rsocket/rsocket-go)         | <ul><li>Go NET (TCP)</li></ul>                                                                       | 1.0     |              |            |         |     |
+| [rsocket-kotlin](https://github.com/rsocket/rsocket-kotlin) | <ul><li>ktor multiplatform<br />(TCP, websocket)</li></ul>                                           | 1.0     | x            |            |         |     |
+| [rsocket-py](https://github.com/rsocket/rsocket-py)         | <ul><li>asyncio (TCP, websocket)</li></ul>                                                           | 1.0     | x            |            | x       |     |
+| [rsocket-swift](https://github.com/rsocket/rsocket-swift)   | <ul><li>SwiftNIO (TCP, WebSocket)</li><li>Network.framework through NIO Transport Services</li></ul> | 0.0.1   |              |            |         |     |

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,8 +91,8 @@ module.exports = {
       "respectPrefersColorScheme": true,
     },
     "prism": {
-      "theme": require("prism-react-renderer/themes/dracula"),
-      "additionalLanguages": ["java", "kotlin"],
+      "theme": require("prism-react-renderer/themes/vsDark"),
+      "additionalLanguages": ["java", "kotlin", "python"],
     },
     "metadatas": [
       { property: "og:image", content: `${deployUrl}/img/social/rsocket-io-facebook-og.jpg` },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -174,6 +174,10 @@ function Home() {
     {
       title: "Swift",
       url: "https://github.com/rsocket/rsocket-swift"
+    },
+    {
+      title: "Python",
+      url: "https://github.com/rsocket/rsocket-py"
     }
   ];
 


### PR DESCRIPTION
Content and configuration changes.

### Motivation:

- Better python syntax highlighting
- Easier discoverability of python implementation

### Modifications:

Change to a syntax highlighting theme that has better support for `python` + adds a link to `rsocket-py` from the implementations list on the homepage.

### Result:

- New link on the index page
- Syntax highlighting in code blocks uses `vsDark` theme

Before:

![image](https://user-images.githubusercontent.com/6305490/152917916-5ac703f6-b7ff-4f18-a9a0-2004fb65babe.png)

After:

![image](https://user-images.githubusercontent.com/6305490/152917946-6695017c-2f97-4449-8c78-f04d86243225.png)
