### PR TITLE
updated rsocket-py examples to match 0.3.dev1 release

### DIFF
--- a/content-docs/guides/rsocket-py/client/introduction.mdx
+++ b/content-docs/guides/rsocket-py/client/introduction.mdx
@@ -97,9 +97,9 @@ from typing import Union
 
 from reactivestreams.publisher import Publisher
 from rsocket.payload import Payload
-from rsocket.streams.stream import Stream
+from rsocket.streams.backpressureapi import BackpressureApi
 
-def request_stream(self, payload: Payload) -> Union[Stream, Publisher]:
+def request_stream(self, payload: Payload) -> Union[BackpressureApi, Publisher]:
     ...
 ```
 
@@ -118,9 +118,9 @@ from typing import Union, Optional
 
 from reactivestreams.publisher import Publisher
 from rsocket.payload import Payload
-from rsocket.streams.stream import Stream
+from rsocket.streams.backpressureapi import BackpressureApi
 
-def request_channel(self, payload: Payload, publisher: Optional[Publisher] = None) -> Union[Stream, Publisher]:
+def request_channel(self, payload: Payload, publisher: Optional[Publisher] = None) -> Union[BackpressureApi, Publisher]:
     ...
 ```
 

--- a/content-docs/guides/rsocket-py/client/rsocket-tcp-client.mdx
+++ b/content-docs/guides/rsocket-py/client/rsocket-tcp-client.mdx
@@ -14,11 +14,12 @@ and is suitable for Server to Server, and other scenarios where raw TCP is avail
 import asyncio
 from rsocket.rsocket_client import RSocketClient
 from rsocket.transports.tcp import TransportTCP
+from rsocket.helpers import single_transport_provider
 
 async def main():
     connection = await asyncio.open_connection('localhost', 6565)
 
-    async with RSocketClient(TransportTCP(*connection)) as client:
+    async with RSocketClient(single_transport_provider(TransportTCP(*connection))) as client:
         ... # Execute requests
 
 if __name__ == '__main__':

--- a/content-docs/guides/rsocket-py/client/rsocket-websocket-client.mdx
+++ b/content-docs/guides/rsocket-py/client/rsocket-websocket-client.mdx
@@ -16,17 +16,21 @@ The Websocket transport for a client side is available by installing rsocket wit
 
 ```py
 import asyncio
+import logging
+import sys
 
 from rsocket.payload import Payload
 from rsocket.transports.aiohttp_websocket import websocket_client
 
 
-async def application():
-    async with websocket_client('http://localhost:6565') as client:
+async def application(serve_port):
+    async with websocket_client('http://localhost:%s' % serve_port) as client:
         result = await client.request_response(Payload(b'ping'))
         print(result)
 
 
 if __name__ == '__main__':
-    asyncio.run(application())
+    port = sys.argv[1] if len(sys.argv) > 1 else 6565
+    logging.basicConfig(level=logging.DEBUG)
+    asyncio.run(application(port))
 ```

--- a/content-docs/guides/rsocket-py/index.mdx
+++ b/content-docs/guides/rsocket-py/index.mdx
@@ -5,7 +5,8 @@ sidebar_label: Introduction
 ---
 
 :::important
-This documentation is for version 0.3.0 of `rsocket` (currently only available via git-hub)
+This documentation is for version 0.3.x of `rsocket` (currently only available via git-hub,
+or via pypi when installing a pre-release using the pip '--pre' flag)
 :::
 
 :::caution
@@ -17,7 +18,8 @@ and is designed for use in python >= 3.8 using asyncio.
 
 ## Packages
 
-A pypi package is available at [rsocket](https://pypi.org/project/rsocket/)
+A pre-release pip package (0.3.devN) is available when installing with
+'pip install --pre rsocket' ([rsocket](https://pypi.org/project/rsocket/))
 
 ## Status
 
@@ -37,26 +39,28 @@ The client sends a `request/response` message to the server on an interval, with
 # client.py
 import asyncio
 import logging
+import sys
 
-from reactivestreams.subscriber import Subscriber
+from reactivestreams.subscriber import DefaultSubscriber
+from rsocket.helpers import single_transport_provider
 from rsocket.payload import Payload
 from rsocket.rsocket_client import RSocketClient
 from rsocket.transports.tcp import TransportTCP
 
 
-class StreamSubscriber(Subscriber):
+class StreamSubscriber(DefaultSubscriber):
 
-    async def on_next(self, value, is_complete=False):
-        await self.subscription.request(1)
-
-    def on_subscribe(self, subscription):
-        self.subscription = subscription
+    def on_next(self, value, is_complete=False):
+        logging.info('RS: {}'.format(value))
+        self.subscription.request(1)
 
 
-async def main():
-    connection = await asyncio.open_connection('localhost', 6565)
+async def main(server_port):
+    logging.info('Connecting to server at localhost:%s', server_port)
 
-    async with RSocketClient(TransportTCP(*connection)) as client:
+    connection = await asyncio.open_connection('localhost', server_port)
+
+    async with RSocketClient(single_transport_provider(TransportTCP(*connection))) as client:
         payload = Payload(b'%Y-%m-%d %H:%M:%S')
 
         async def run_request_response():
@@ -76,8 +80,9 @@ async def main():
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
-    asyncio.run(main())
+    port = sys.argv[1] if len(sys.argv) > 1 else 6565
+    logging.basicConfig(level=logging.DEBUG)
+    asyncio.run(main(port))
 ```
 
 ### Server Example
@@ -88,8 +93,10 @@ The server responds to `request/response` messages with the current formatted da
 # server.py
 import asyncio
 import logging
+import sys
 from datetime import datetime
 
+from rsocket.helpers import create_future
 from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
 from rsocket.rsocket_server import RSocketServer
@@ -99,26 +106,27 @@ from rsocket.transports.tcp import TransportTCP
 class Handler(BaseRequestHandler):
     async def request_response(self, payload: Payload) -> asyncio.Future:
         await asyncio.sleep(0.1)  # Simulate not immediate process
-        future = asyncio.Future()
         date_time_format = payload.data.decode('utf-8')
         formatted_date_time = datetime.now().strftime(date_time_format)
-        future.set_result(Payload(formatted_date_time.encode('utf-8')))
-        return future
+        return create_future(Payload(formatted_date_time.encode('utf-8')))
 
 
-async def run_server():
+async def run_server(server_port):
+    logging.info('Starting server at localhost:%s', server_port)
+
     def session(*connection):
         RSocketServer(TransportTCP(*connection), handler_factory=Handler)
 
-    server = await asyncio.start_server(session, 'localhost', 6565)
+    server = await asyncio.start_server(session, 'localhost', server_port)
 
     async with server:
         await server.serve_forever()
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
-    asyncio.run(run_server())
+    port = sys.argv[1] if len(sys.argv) > 1 else 6565
+    logging.basicConfig(level=logging.DEBUG)
+    asyncio.run(run_server(port))
 ```
 
 ## More Examples

--- a/content-docs/guides/rsocket-py/rxpy/introduction.mdx
+++ b/content-docs/guides/rsocket-py/rxpy/introduction.mdx
@@ -42,10 +42,11 @@ from rsocket.rx_support.rx_rsocket import RxRSocket
 import asyncio
 from rsocket.rsocket_client import RSocketClient
 from rsocket.transports.tcp import TransportTCP
+from rsocket.helpers import single_transport_provider
 
 async def main():
     connection = await asyncio.open_connection('localhost', 6565)
-    client = RSocketClient(TransportTCP(*connection))
+    client = RSocketClient(single_transport_provider(TransportTCP(*connection)))
 
     async with RxRSocket(client) as rx_client:
         ... # Execute requests

--- a/content-docs/guides/rsocket-py/server/introduction.mdx
+++ b/content-docs/guides/rsocket-py/server/introduction.mdx
@@ -31,23 +31,26 @@ This object is responsible for mapping callback/handler functions to the various
 and returning an appropriate Publisher/Future that will produce data for the request.
 
 ```py
-from asyncio import Future
-from typing import Tuple
+import asyncio
+from typing import Tuple, Optional
+from datetime import timedelta
 
 from reactivestreams.publisher import Publisher
 from reactivestreams.subscriber import Subscriber
 from rsocket.payload import Payload
 from rsocket.request_handler import RequestHandler
+from rsocket.error_codes import ErrorCode
 
 
 class CustomRequestHandler(RequestHandler):
 
     async def on_setup(self,
                        data_encoding: bytes,
-                       metadata_encoding: bytes):
+                       metadata_encoding: bytes,
+                       payload: Payload):
         ...
 
-    async def request_channel(self, payload: Payload) -> Tuple[Publisher, Subscriber]:
+    async def request_channel(self, payload: Payload) -> Tuple[Optional[Publisher], Optional[Subscriber]]:
         ...
 
     async def request_fire_and_forget(self, payload: Payload):
@@ -56,10 +59,21 @@ class CustomRequestHandler(RequestHandler):
     async def on_metadata_push(self, payload: Payload):
         ...
 
-    async def request_response(self, payload: Payload) -> Future:
+    async def request_response(self, payload: Payload) -> asyncio.Future:
         ...
 
     async def request_stream(self, payload: Payload) -> Publisher:
+        ...
+
+    async def on_error(self, error_code: ErrorCode, payload: Payload):
+        ...
+
+    async def on_keepalive_timeout(self,
+                                   time_since_last_keepalive: timedelta,
+                                   rsocket):
+        ...
+
+    async def on_connection_lost(self, rsocket, exception):
         ...
 ```
 

--- a/content-docs/guides/rsocket-py/server/rsocket-tcp-server.mdx
+++ b/content-docs/guides/rsocket-py/server/rsocket-tcp-server.mdx
@@ -13,6 +13,8 @@ In order to use a basic TCP transport, instantiate a `TransportTCP` and pass it 
 
 ```py
 import asyncio
+import logging
+import sys
 
 from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
@@ -25,16 +27,20 @@ class Handler(BaseRequestHandler):
         ...
 
 
-async def run_server():
+async def run_server(server_port):
+    logging.info('Starting server at localhost:%s', server_port)
+
     def session(*connection):
         RSocketServer(TransportTCP(*connection), handler_factory=Handler)
 
-    server = await asyncio.start_server(session, 'localhost', 6565)
+    server = await asyncio.start_server(session, 'localhost', server_port)
 
     async with server:
         await server.serve_forever()
 
 
 if __name__ == '__main__':
-    asyncio.run(run_server())
+    port = sys.argv[1] if len(sys.argv) > 1 else 6565
+    logging.basicConfig(level=logging.DEBUG)
+    asyncio.run(run_server(port))
 ```

--- a/content-docs/guides/rsocket-py/server/rsocket-websocket-server.mdx
+++ b/content-docs/guides/rsocket-py/server/rsocket-websocket-server.mdx
@@ -20,34 +20,42 @@ and pass it to an `RSocketServer` instance. There are a few helpers to ease the 
 Example using `aiohttp`:
 
 ```py
+import logging
+import sys
 from asyncio import Future
 
 from aiohttp import web
 
+from rsocket.helpers import create_future
 from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
-from rsocket.transports.websocket import websocket_handler_factory
+from rsocket.transports.aiohttp_websocket import websocket_handler_factory
 
 
 class Handler(BaseRequestHandler):
 
     async def request_response(self, payload: Payload) -> Future:
-        ...
+        return create_future(Payload(b'pong'))
 
 
 if __name__ == '__main__':
+    port = sys.argv[1] if len(sys.argv) > 1 else 6565
+    logging.basicConfig(level=logging.DEBUG)
     app = web.Application()
     app.add_routes([web.get('/', websocket_handler_factory(handler_factory=Handler))])
-    web.run_app(app, port=6565)
+    web.run_app(app, port=port)
 ```
 
 Example using `quart`:
 
 ```py
+import logging
+import sys
 from asyncio import Future
 
 from quart import Quart
 
+from rsocket.helpers import create_future
 from rsocket.payload import Payload
 from rsocket.request_handler import BaseRequestHandler
 from rsocket.transports.quart_websocket import websocket_handler
@@ -58,7 +66,7 @@ app = Quart(__name__)
 class Handler(BaseRequestHandler):
 
     async def request_response(self, payload: Payload) -> Future:
-        ...
+        return create_future(Payload(b'pong'))
 
 
 @app.websocket("/")
@@ -67,5 +75,7 @@ async def ws():
 
 
 if __name__ == "__main__":
-    app.run(port=6565)
+    port = sys.argv[1] if len(sys.argv) > 1 else 6565
+    logging.basicConfig(level=logging.DEBUG)
+    app.run(port=port)
 ```


### PR DESCRIPTION
updated rsocket-py examples to match 0.3.dev1 release

### Motivation:

up-to-date getting started guide

### Modifications:

updated example code and mentioned pypi pre-release package

### Result:

updated documentation
