### PR TITLE
docs(rsocket-py): update metadata for more SEO friendly page titles

### DIFF
--- a/content-docs/guides/rsocket-py/cli.mdx
+++ b/content-docs/guides/rsocket-py/cli.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/cli
-title: Command Line Interface
+title: Command Line Interface - rsocket-py
 sidebar_label: Command Line Interface
 ---
+
+# Command Line Interface
 
 Rsocket requests can be sent using the command line interface. It is available when installing with pip using the [cli] extra.
 

--- a/content-docs/guides/rsocket-py/client/introduction.mdx
+++ b/content-docs/guides/rsocket-py/client/introduction.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/client
-title: Client - Introduction
+title: Client Introduction - rsocket-py
 sidebar_label: Introduction
 ---
+
+# Client Introduction
 
 An `rsocket-py` client can be used to communicate with any RSocket Server implemented against the same protocol version as the client,
 and which implements the same transport as the client.

--- a/content-docs/guides/rsocket-py/client/rsocket-tcp-client.mdx
+++ b/content-docs/guides/rsocket-py/client/rsocket-tcp-client.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/client/rsocket-tcp-client
-title: Client - TCP Transport
+title: TCP Client Transport - rsocket-py
 sidebar_label: TCP Transport
 ---
+
+# TCP Client Transport
 
 The `TransportTCP` implements the RSocket protocol using the TCP network transport protocol,
 and is suitable for Server to Server, and other scenarios where raw TCP is available.

--- a/content-docs/guides/rsocket-py/client/rsocket-websocket-client.mdx
+++ b/content-docs/guides/rsocket-py/client/rsocket-websocket-client.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/client/rsocket-websocket-client
-title: Client - WebSocket Transport
+title: WebSocket Client Transport - rsocket-py
 sidebar_label: WebSocket Transport
 ---
+
+# WebSocket Client Transport
 
 The `RSocketClient` implements the RSocket protocol, and when used with a websocket `Transport` implementation,
 is suitable for Server to Server, and Client to Server scenarios where raw TCP is not available, such as in a web browser.

--- a/content-docs/guides/rsocket-py/graphql/index.mdx
+++ b/content-docs/guides/rsocket-py/graphql/index.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/graphql
-title: GraphQL integration
+title: GraphQL Integration - rsocket-py
 sidebar_label: Introduction
 ---
+
+# GraphQL Integration
 
 This guide will go over using GraphQL over RSocket, both client and server side.
 This document assumes you know how to set up an RSocket server with a routing handler.

--- a/content-docs/guides/rsocket-py/graphql/mutation.mdx
+++ b/content-docs/guides/rsocket-py/graphql/mutation.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/graphql/mutation
-title: Mutation
+title: Mutation - GraphQL Integration - rsocket-py
 sidebar_label: Mutation
 ---
+
+# Mutation
 
 In this section we will add an example for `Mutation`.
 

--- a/content-docs/guides/rsocket-py/index.mdx
+++ b/content-docs/guides/rsocket-py/index.mdx
@@ -4,6 +4,8 @@ title: rsocket-py
 sidebar_label: Introduction
 ---
 
+# rsocket-py Introduction
+
 :::caution
 The python package API is not stable. There may be changes until version 1.0.0.
 :::

--- a/content-docs/guides/rsocket-py/rxpy.mdx
+++ b/content-docs/guides/rsocket-py/rxpy.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/rxpy
-title: RxPy integration
+title: RxPy Integration - rsocket-py
 sidebar_label: RxPy integration
 ---
+
+# RxPy Integration
 
 The `rsocket-py` implementation doesn't use [RxPy](https://pypi.org/project/Rx/) by default. A wrapper class `RxRSocketClient`
 can be used to interact with [RxPy](https://pypi.org/project/Rx/) (>= 3.2.0) entities (`Observable`, `Observer`)

--- a/content-docs/guides/rsocket-py/server/introduction.mdx
+++ b/content-docs/guides/rsocket-py/server/introduction.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/server
-title: Server - Introduction
+title: Server Introduction - rsocket-py
 sidebar_label: Introduction
 ---
+
+# Server Introduction
 
 `RSocketServer` is the high level abstraction leveraged to create a server running the RSocket protocol.
 It is a subclass of `RSocket`.

--- a/content-docs/guides/rsocket-py/server/rsocket-tcp-server.mdx
+++ b/content-docs/guides/rsocket-py/server/rsocket-tcp-server.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/server/rsocket-tcp-server
-title: Server - TCP Transport
+title: TCP Server Transport - rsocket-py
 sidebar_label: TCP Transport
 ---
+
+# TCP Server Transport
 
 `rsocket-py` supports multiple transport protocols. The TCP transport is available by default.
 In order to use a basic TCP transport, instantiate a `TransportTCP` and pass it to an `RSocketServer` instance.

--- a/content-docs/guides/rsocket-py/server/rsocket-websocket-server.mdx
+++ b/content-docs/guides/rsocket-py/server/rsocket-websocket-server.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/server/rsocket-websocket-server
-title: Server - Websocket Transport
+title: Websocket Server Transport - rsocket-py
 sidebar_label: WebSocket Transport
 ---
+
+# Websocket Server Transport
 
 `rsocket-py` supports multiple transport protocols. The Websocket transport is available by installing rsocket using one
 of the extra features:

--- a/content-docs/guides/rsocket-py/simple.mdx
+++ b/content-docs/guides/rsocket-py/simple.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/simple
-title: Simple Quickstart
+title: Simple Quickstart - rsocket-py
 sidebar_label: Simple Quickstart
 ---
+
+# Simple Quickstart
 
 ## Client Example
 

--- a/content-docs/guides/rsocket-py/tutorial/00-base.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/00-base.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/base
-title: Getting started
+title: Getting Started - Tutorial - rsocket-py
 sidebar_label: Getting started
 ---
+
+# Getting Started
 
 ## Application structure
 

--- a/content-docs/guides/rsocket-py/tutorial/01-request_routing.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/01-request_routing.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/request_routing
-title: Request routing
+title: Request Routing - Tutorial - rsocket-py
 sidebar_label: Request routing
 ---
+
+# Request Routing
 
 In the previous step we added a single request-response handler. In order to allow more than one functionality to use this handler,
 (e.g. login, messages, join/leave chanel) they need to be distinguished from each other. To achieve this, each request to the server will

--- a/content-docs/guides/rsocket-py/tutorial/02-user_session.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/02-user_session.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/user_session
-title: User session
+title: User Session - Tutorial - rsocket-py
 sidebar_label: User session
 ---
+
+# User Session
 
 Let's add a server side session to store the logged-in user's state. Later on it will be used to temporarily store
 the messages which will be delivered to the client.

--- a/content-docs/guides/rsocket-py/tutorial/03-messages.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/03-messages.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/messages
-title: Private messages
+title: Private Messages - Tutorial - rsocket-py
 sidebar_label: Private messages
 ---
+
+# Private Messages
 
 Let's add private messaging between users. We will use a request-stream to listen for new messages from other users.
 

--- a/content-docs/guides/rsocket-py/tutorial/04-channels.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/04-channels.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/channels
-title: Channels
+title: Channels - Tutorial - rsocket-py
 sidebar_label: Channels
 ---
+
+# Channels
 
 In this section we will add basic channel support:
 - Joining and leaving channels

--- a/content-docs/guides/rsocket-py/tutorial/04-files.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/04-files.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/files
-title: File upload/download
+title: File Upload & Download - Tutorial - rsocket-py
 sidebar_label: File upload/download
 ---
+
+# File Upload & Download
 
 In this section we will add very basic file upload/download functionality. All files will be stored in memory,
 and downloadable by all users.

--- a/content-docs/guides/rsocket-py/tutorial/05-statistics.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/05-statistics.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/statistics
-title: Statistics
+title: Statistics - Tutorial - rsocket-py
 sidebar_label: Statistics
 ---
+
+# Statistics
 
 As a last step, we will add passing some statistics between the client and the server:
 - The client will be able to send its memory usage to the server.

--- a/content-docs/guides/rsocket-py/tutorial/06-client_side_handler.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/06-client_side_handler.mdx
@@ -1,5 +1,5 @@
 ---
 slug: /guides/rsocket-py/tutorial/client_side_handler
-title: Client side handler
+title: Client side handler - Tutorial - rsocket-py
 sidebar_label: Client side handler
 ---

--- a/content-docs/guides/rsocket-py/tutorial/07-reactivex.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/07-reactivex.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/reactivex
-title: Reactivex
+title: Reactivex - Tutorial - rsocket-py
 sidebar_label: Reactivex
 ---
+
+# Reactivex
 
 Up until now we only used the core RSocket python library. We will now simplify some code using the [Reactivex](https://rxpy.readthedocs.io) integration.
 Well show an implementation using version 4. The implementation with version 3 mostly requires some module import changes.

--- a/content-docs/guides/rsocket-py/tutorial/08-websocket.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/08-websocket.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial/websocket
-title: Websocket
+title: Websocket - Tutorial - rsocket-py
 sidebar_label: Websocket
 ---
+
+# WebSocket Transport
 
 Up until now the transport used was TCP. Let's change the transport to be Secure Websocket. For this purpose we will use
 and [aiohttp](https://pypi.org/project/aiohttp/) server and client. You may ensure the package is installed using the rsocket pip extrac (aiohttp):

--- a/content-docs/guides/rsocket-py/tutorial/index.mdx
+++ b/content-docs/guides/rsocket-py/tutorial/index.mdx
@@ -1,8 +1,10 @@
 ---
 slug: /guides/rsocket-py/tutorial
-title: Chat Application
+title: Chat Application - Tutorial - rsocket-py
 sidebar_label: Preface
 ---
+
+# Chat Application Tutorial
 
 This guide will go over step by step of setting up an application using the python implementation of RSocket.
 


### PR DESCRIPTION
### Motivation:

Improved SEO by including `rsocket-py` in the HTML `<title>` tag that will be indexed by Google.

### Modifications:

- Adds `rsocket-py` to end of the page title for each page
- Adds `Tutorial` to the page title for tutorial pages
- Adds a H1 tag via `#` on pages to override the page using the value from `title:`

### Result:

See page preview deployment.
