### PR TITLE
docs: add note highlighting that rsocket-js guides pertain to 0.x 

### DIFF
--- a/content-docs/guides/rsocket-js/client/introduction.mdx
+++ b/content-docs/guides/rsocket-js/client/introduction.mdx
@@ -4,6 +4,10 @@ title: RSocketClient - rsocket-js
 sidebar_label: Introduction
 ---
 
+:::note
+This guide pertains to rsocket-js `0.x` versions. Ensure that your version of `rsocket-` packages are not `1.0.0-alpha` before following this guide.
+:::
+
 An `rsocket-js` client can be used to communicate with any RSocket Server implemented against the same protocol version as the client, and which implements the same transport as the client.
 
 Available transports for `rsocket-js` include:

--- a/content-docs/guides/rsocket-js/client/rsocket-tcp-client.mdx
+++ b/content-docs/guides/rsocket-js/client/rsocket-tcp-client.mdx
@@ -12,6 +12,10 @@ RSocketTCPClient is not supported in web browser environments. For web browser e
 
 ### TCP Client Quick Start Example
 
+:::note
+This guide pertains to rsocket-js `0.x` versions. Ensure that your version of `rsocket-` packages are not `1.0.0-alpha` before following this guide.
+:::
+
 ```
 npm install rsocket-core rsocket-tcp-client
 ```

--- a/content-docs/guides/rsocket-js/client/rsocket-websocket-client.mdx
+++ b/content-docs/guides/rsocket-js/client/rsocket-websocket-client.mdx
@@ -4,9 +4,15 @@ title: RSocketWebsocketClient - rsocket-js
 sidebar_label: WebSocket Client
 ---
 
+
+
 The `RSocketWebsocketClient` implements the RScocket protocol using the WebSocket network transport protocol, and is suitable for Server to Server, and Client to Server scenarios where raw TCP is not available, such as in a web browser.
 
 ### WebSocket Client Quick Start Example
+
+:::note
+This guide pertains to rsocket-js `0.x` versions. Ensure that your version of `rsocket-` packages are not `1.0.0-alpha` before following this guide.
+:::
 
 ```
 npm install rsocket-core rsocket-websocket-client

--- a/content-docs/guides/rsocket-js/rsocket-flowable/introduction.mdx
+++ b/content-docs/guides/rsocket-js/rsocket-flowable/introduction.mdx
@@ -4,6 +4,10 @@ title: rsocket-flowable
 sidebar_label: Introduction
 ---
 
+:::note
+This guide pertains to rsocket-js `0.x` versions. Ensure that your version of `rsocket-` packages are not `1.0.0-alpha` before following this guide.
+:::
+
 ## Reactive Streams
 
 `rsocket-js` includes an implementation of the [Reactive Streams](http://www.reactive-streams.org/)

--- a/content-docs/guides/rsocket-js/server/introduction.mdx
+++ b/content-docs/guides/rsocket-js/server/introduction.mdx
@@ -4,6 +4,10 @@ title: RSocketServer - rsocket-js
 sidebar_label: Introduction
 ---
 
+:::note
+This guide pertains to rsocket-js `0.x` versions. Ensure that your version of `rsocket-` packages are not `1.0.0-alpha` before following this guide.
+:::
+
 `RSocketServer` is the high level abstraction leveraged to create a server running the RSocket protocol.
 
 An `RSocketServer` server can be used to communicate with any RSocket Client implemented against the same protocol version as the server, and which implements the same transport as the server.

--- a/content-docs/guides/rsocket-js/server/rsocket-tcp-server.mdx
+++ b/content-docs/guides/rsocket-js/server/rsocket-tcp-server.mdx
@@ -4,11 +4,11 @@ title: RSocketTCPServer - rsocket-js
 sidebar_label: TCP Server
 ---
 
-## Getting Started
-
-TODO
-
 ## Example
+
+:::note
+This guide pertains to rsocket-js `0.x` versions. Ensure that your version of `rsocket-` packages are not `1.0.0-alpha` before following this guide.
+:::
 
 ```
 npm install rsocket-core rsocket-tcp-server rsocket-flowable

--- a/content-docs/guides/rsocket-js/server/rsocket-websocket-server.mdx
+++ b/content-docs/guides/rsocket-js/server/rsocket-websocket-server.mdx
@@ -4,11 +4,11 @@ title: RSocketWebSocketServer - rsocket-js
 sidebar_label: WebSocket Server
 ---
 
-## Getting Started
-
-TODO
-
 ## Example
+
+:::note
+This guide pertains to rsocket-js `0.x` versions. Ensure that your version of `rsocket-` packages are not `1.0.0-alpha` before following this guide.
+:::
 
 ```
 npm install rsocket-core rsocket-websocket-server rsocket-flowable


### PR DESCRIPTION
### Motivation:

Help avoid confusion where new users try and follow the existing guides with the `1.0.0-alpha` versions.

Related to https://github.com/rsocket/rsocket-js/issues/263

### Modifications:

Added note to top of relevant `rsocket-js` guides.

