### PR TITLE
feat: enable syntax highlight for flow

### DIFF
--- a/content-docs/guides/rsocket-js/client/introduction.mdx
+++ b/content-docs/guides/rsocket-js/client/introduction.mdx
@@ -69,6 +69,8 @@ The `rsocket-core` package exposes the the following types:
 ### constructor (function)
 
 ```flow
+// @flow
+
 class RSocketClient {
   constructor(options: Options)
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,7 +101,7 @@ module.exports = {
     },
     "prism": {
       "theme": require("prism-react-renderer/themes/vsDark"),
-      "additionalLanguages": ["java", "kotlin", "python"],
+      "additionalLanguages": ["java", "kotlin", "python", "flow"],
     },
     "metadata": [
       { property: "og:image", content: `${deployUrl}/img/social/rsocket-io-facebook-og.jpg` },


### PR DESCRIPTION

### Motivation:

Make it more apparent that code examples using Flow lang are not Typescript.

### Modifications:

- Load additional syntax highlighting config for Flow.
- Add `// @flow` comment to flow code examples

### Result:

Flow code blocks use syntax highlighting
